### PR TITLE
Fix typo to run "go get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Install
 ```
-go get github.com/gogle/tfidf
+go get github.com/goglue/tfidf
 ```
 
 ### How to use


### PR DESCRIPTION
It needs to be fixed to run "go get" for copy & paste.